### PR TITLE
Improve cody pull: skip existing repos and add colorized output

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,5 @@ In order to get the benefit of some features in cody you will need to copy the f
 ```
 function cody_cd() {
     eval $(cody open $@)
-    cd $(cat /tmp/cody_result)
 }
 ```


### PR DESCRIPTION
## Summary
- Skip repos that already exist (fast `.git` directory check) instead of showing "Clone failed"
- Skip unsupported URL formats with informative message
- Add colorized terminal output (gray=skipped, blue=cloning/success, red=failed)

## Test plan
- [x] Run `cody pull` with repos that already exist - should show "Skipped (already exists)" in gray
- [x] Run `cody pull` with new repos - should clone successfully with blue output
- [x] Run `cody pull` with invalid URLs - should show "Skipped (unsupported URL format)" in gray