### PR TITLE
Make cody add code_path optional, default to uncategorized

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,10 +27,10 @@ var searchCmd = &cobra.Command{
 }
 
 var addCmd = &cobra.Command{
-	Use:   "add [code_path] [git_url]",
+	Use:   "add [git_url] [code_path]",
 	Short: "Add a new code entry",
-	Long:  "Add a new code entry to the cody files",
-	Args:  cobra.ExactArgs(2),
+	Long:  "Add a new code entry to the cody files. If code_path is omitted, defaults to 'uncategorized'.",
+	Args:  cobra.RangeArgs(1, 2),
 	RunE:  runAdd,
 }
 
@@ -91,8 +91,11 @@ func runSearch(cmd *cobra.Command, args []string) error {
 }
 
 func runAdd(cmd *cobra.Command, args []string) error {
-	codePath := args[0]
-	gitURL := args[1]
+	gitURL := args[0]
+	codePath := "uncategorized"
+	if len(args) > 1 {
+		codePath = args[1]
+	}
 
 	var filePath = resolveCodyConfig(codePath + ".code")
 

--- a/main_test.go
+++ b/main_test.go
@@ -172,7 +172,7 @@ func TestRunAdd(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := runAdd(nil, []string{tt.codePath, tt.gitURL})
+			err := runAdd(nil, []string{tt.gitURL, tt.codePath})
 			if (err != nil) != tt.wantError {
 				t.Errorf("runAdd() error = %v, wantError %v", err, tt.wantError)
 			}


### PR DESCRIPTION
## Summary
- Swap argument order: `git_url` first (required), `code_path` second (optional)
- Default `code_path` to "uncategorized" when omitted

## Usage
```bash
cody add git@github.com:user/repo.git           # saves to uncategorized.code
cody add git@github.com:user/repo.git myproject # saves to myproject.code
```

## Test plan
- [x] Run `cody add git@example.com:test/repo.git` - should save to uncategorized.code
- [x] Run `cody add git@example.com:test/repo.git custom` - should save to custom.code