### PR TITLE
Add install script for easy installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,9 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
       - name: Create Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -20,6 +23,14 @@ jobs:
             --repo ${{ github.repository }} \
             --title "Release ${{ github.ref_name }}" \
             --generate-notes || true
+
+      - name: Upload install script
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ github.ref_name }} \
+            install.sh \
+            --repo ${{ github.repository }}
 
   build:
     needs: create-release

--- a/README.md
+++ b/README.md
@@ -18,14 +18,30 @@ Cody can then run various tasks for these repositories
 
 ### Installation
 
+#### Quick Install (Recommended)
+
+```bash
+curl -sL https://github.com/alexjpaz/cody/releases/latest/download/install.sh | bash
+```
+
+#### Manual Install
+
 Download the [latest release binary](https://github.com/alexjpaz/cody/releases) for your OS.
 
 Copy the binary to a directory in your `$PATH` (e.g. /usr/local/bin)
 
+#### Using Go
+
+```bash
+go install github.com/alexjpaz/cody@latest
+```
+
+#### Setup
+
 You will need to add some git repo urls to the `~/.code.d` directory.
 
 ```
-mkdir -o ~/.code.d/
+mkdir -p ~/.code.d/
 echo "git@github.com:alexjpaz/cody.git" >> ~/.code.d/github.code
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -e
+
+REPO="alexjpaz/cody"
+INSTALL_DIR="${INSTALL_DIR:-/usr/local/bin}"
+
+# Detect OS
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+case "$OS" in
+    linux*)  OS="linux" ;;
+    darwin*) OS="darwin" ;;
+    *)       echo "Unsupported OS: $OS"; exit 1 ;;
+esac
+
+# Detect architecture
+ARCH="$(uname -m)"
+case "$ARCH" in
+    x86_64)  ARCH="amd64" ;;
+    amd64)   ARCH="amd64" ;;
+    *)       echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+BINARY="cody-${OS}-${ARCH}"
+
+# Get latest release tag
+echo "Fetching latest release..."
+LATEST=$(curl -s "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
+
+if [ -z "$LATEST" ]; then
+    echo "Failed to fetch latest release"
+    exit 1
+fi
+
+echo "Latest version: $LATEST"
+
+# Download URL
+URL="https://github.com/${REPO}/releases/download/${LATEST}/${BINARY}"
+
+echo "Downloading $BINARY..."
+curl -sL "$URL" -o /tmp/cody
+
+# Make executable
+chmod +x /tmp/cody
+
+# Install
+echo "Installing to ${INSTALL_DIR}/cody..."
+if [ -w "$INSTALL_DIR" ]; then
+    mv /tmp/cody "${INSTALL_DIR}/cody"
+else
+    sudo mv /tmp/cody "${INSTALL_DIR}/cody"
+fi
+
+echo "Done! cody $LATEST installed to ${INSTALL_DIR}/cody"


### PR DESCRIPTION
## Summary
- Add `install.sh` script that auto-detects OS/arch and downloads the latest release binary
- Update release workflow to include `install.sh` in each release
- Update README with quick install command (`curl | bash`) while preserving manual instructions