### PR TITLE
Add macOS arm64 (Apple Silicon) support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,9 @@ jobs:
       matrix:
         goos: [linux, darwin, windows]
         goarch: [amd64]
+        include:
+          - goos: darwin
+            goarch: arm64
 
     steps:
       - name: Checkout

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,8 @@ ARCH="$(uname -m)"
 case "$ARCH" in
     x86_64)  ARCH="amd64" ;;
     amd64)   ARCH="amd64" ;;
+    arm64)   ARCH="arm64" ;;
+    aarch64) ARCH="arm64" ;;
     *)       echo "Unsupported architecture: $ARCH"; exit 1 ;;
 esac
 


### PR DESCRIPTION
## Summary
- Add darwin/arm64 build target to release workflow for Apple Silicon Macs
- Update install script to detect arm64/aarch64 architecture